### PR TITLE
Scan should return output length

### DIFF
--- a/GoHttp.c
+++ b/GoHttp.c
@@ -202,7 +202,7 @@ int scan(char *input, char *output, int start, int max)
 			break;
 	}
 
-	return i;
+	return i - start;
 }
 
 

--- a/GoHttp.c
+++ b/GoHttp.c
@@ -202,11 +202,8 @@ int scan(char *input, char *output, int start, int max)
 			break;
 	}
 
-	return i - start;
+	return strlen(output);
 }
-
-
-
 
 int checkMime(char *extension, char *mime_type)
 {


### PR DESCRIPTION
this change will make scan return the length of the output string. Closes #13 